### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/storefrontcloud-action.yml
+++ b/.github/workflows/storefrontcloud-action.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           node-version: "16.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.PROJECT_NAME }}-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}
@@ -96,7 +96,7 @@ jobs:
         with:
           node-version: "16.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.PROJECT_NAME }}-storefrontcloud-io/vue-storefront-middleware:${{ github.sha }}
           registry: ${{ secrets.DOCKER_REGISTRY_URL }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore